### PR TITLE
fix: schedule when daylight savings

### DIFF
--- a/.github/workflows/send-notifications.yml
+++ b/.github/workflows/send-notifications.yml
@@ -1,8 +1,12 @@
-name: Update FX Rates
+name: Send notfications
 
 on:
   schedule:
-    - cron: '0/5 8-20 * * *'
+    # Winter Schedule: Every 5 minutes from 06:00-18:00 UTC (07:00-19:00 CET)
+    - cron: '0/5 7-19 * 11-12,1-3 *'
+
+    # Summer Schedule: Every 5 minutes from 04:00-16:00 UTC (06:00-18:00 CEST)
+    - cron: '0/5 6-18 * 4-10 *'
   workflow_dispatch:  
 
 jobs:

--- a/.github/workflows/send-notifications.yml
+++ b/.github/workflows/send-notifications.yml
@@ -2,10 +2,10 @@ name: Send notfications
 
 on:
   schedule:
-    # Winter Schedule: Every 5 minutes from 06:00-18:00 UTC (07:00-19:00 CET)
+    # Winter Schedule: 07:00-19:00 UTC
     - cron: '0/5 7-19 * 11-12,1-3 *'
 
-    # Summer Schedule: Every 5 minutes from 04:00-16:00 UTC (06:00-18:00 CEST)
+    # Summer Schedule: 06:00-18:00 UTC
     - cron: '0/5 6-18 * 4-10 *'
   workflow_dispatch:  
 


### PR DESCRIPTION
Splits the cron expression such that it runs 08-20 CST/CEST, no matter if it is summer time or not. 

For now it runs a bit off late march and late october, as I didn't really  bother nailing the cron expression to the exact day it happens (it varies too - so let's just have it this way for now..)